### PR TITLE
Native cluster controller install support

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -115,6 +115,7 @@ default["eucalyptus"]["network"]["disable-tunneling"] = "Y"
 default["eucalyptus"]["cc"]["port"] = "8774"
 default["eucalyptus"]["cc"]["scheduling-policy"] = "ROUNDROBIN"
 default["eucalyptus"]["cc"]["max-instances-per-cc"] = "128"
+default["eucalyptus"]["cc"]["native"] = false
 
 ## Storage
 default["eucalyptus"]["storage"]["emc"]["navicli-url"] = "http://mirror.eucalyptus-systems.com/mirrors/emc/NaviCLI-Linux-64-latest.rpm"

--- a/templates/default/eucalyptus.conf.erb
+++ b/templates/default/eucalyptus.conf.erb
@@ -1,7 +1,7 @@
 EUCALYPTUS="<%= node["eucalyptus"]["home-directory"] %>"
 LOGLEVEL="<%= node["eucalyptus"]["log-level"] %>"
 EUCA_USER="<%= node["eucalyptus"]["user"] %>"
-CLOUD_OPTS="<%= node["eucalyptus"]["cloud-opts"] %>"
+CLOUD_OPTS="<%= node["eucalyptus"]["cloud-opts"] %><%= " -Dcom.eucalyptus.cluster.service=default" if not node["eucalyptus"]["cc"]["native"] and node["eucalyptus"]["install-type"] == "sources" %>"
 CC_PORT="<%= node["eucalyptus"]["cc"]["port"] %>"
 SCHEDPOLICY="<%= node["eucalyptus"]["cc"]["scheduling-policy"] %>"
 <% if node["eucalyptus"]["nodes"] -%>


### PR DESCRIPTION
In 5.0 the default cluster controller is not httpd/axis based and runs as a regular eucalyptus-cloud service. This update adds an option for installing the legacy cluster controller for both source and package installs. For source installs a CLOUD_OPTS setting is needed as both implementations are present (by default we'll use the native cluster controller if it is installed)