### PR TITLE
Use euca-describe-instance-types for resource availability check

### DIFF
--- a/recipes/create-first-resources.rb
+++ b/recipes/create-first-resources.rb
@@ -68,7 +68,7 @@ execute "Ensure default image is public" do
 end
 
 execute "Wait for resource availability" do
-  command "euca-describe-availability-zones --region #{node["eucalyptus"]["dns-domain"]} verbose | grep m1.small | grep -v 0000"
+  command "euca-describe-instance-types --region #{node["eucalyptus"]["dns-domain"]} --show-capacity | tail --lines=+2 | grep '%'"
   retries 50
   retry_delay 10
 end


### PR DESCRIPTION
Use `euca-describe-instance-types` instead of the deprecated `euca-describe-availability-zones verbose` command option. This also avoids using any particular instance type (`m1.small`) since the available types may vary by eucalyptus cloud version.