### PR TITLE
Allow use of centos/rhel 7.8 and 7.9 for faststart installs

### DIFF
--- a/faststart/cloud-in-a-box.sh
+++ b/faststart/cloud-in-a-box.sh
@@ -288,12 +288,12 @@ fi
 
 # Check to see that we're running on CentOS or RHEL and the right version.
 echo "[Precheck] Checking OS"
-cat /etc/redhat-release | egrep 'release.*7.[34567]' 1>&4 2>&4
+cat /etc/redhat-release | egrep 'release.*7.[3456789]' 1>&4 2>&4
 if [ "$?" != "0" ]; then
     echo "======"
     echo "[FATAL] Operating system not supported"
     echo ""
-    echo "Please note: Eucalyptus Faststart only runs on RHEL or CentOS 7.3-7.7"
+    echo "Please note: Eucalyptus Faststart only runs on RHEL or CentOS 7.3+"
     echo ""
     echo ""
     exit 10


### PR DESCRIPTION
Allow use of centos/rhel 7.8 (and 7.9 when released) for faststart installs